### PR TITLE
assisted-chat logs collapse integration panels under row

### DIFF
--- a/dashboards/assisted-chat/grafana-dashboard-assisted-chat-logs.yaml
+++ b/dashboards/assisted-chat/grafana-dashboard-assisted-chat-logs.yaml
@@ -38,7 +38,7 @@ data:
       "links": [],
       "panels": [
         {
-          "collapsed": true,
+          "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,


### PR DESCRIPTION
to have the Integration row contain the panels, same as Stage