### PR TITLE
Don't require root path in assisted chat metrics

### DIFF
--- a/dashboards/assisted-chat/grafana-dashboard-assisted-chat-overview.yaml
+++ b/dashboards/assisted-chat/grafana-dashboard-assisted-chat-overview.yaml
@@ -131,7 +131,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(ls_rest_api_calls_total{namespace=\"$namespace\",path=\"/\",status_code=~\"2.*\"}[10m])) / sum(rate(ls_rest_api_calls_total{namespace=\"$namespace\",path=\"/\"}[10m]))",
+              "expr": "sum(rate(ls_rest_api_calls_total{namespace=\"$namespace\",status_code=~\"2.*\"}[10m])) / sum(rate(ls_rest_api_calls_total{namespace=\"$namespace\"}[10m]))",
               "legendFormat": "assisted-chat",
               "range": true,
               "refId": "A"
@@ -227,7 +227,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum by (service) (rate(ls_response_duration_seconds_sum{namespace=\"$namespace\",path=\"/\"}[10m])) /\nsum by (service) (rate(ls_response_duration_seconds_count{namespace=\"$namespace\",path=\"/\"}[10m]))",
+              "expr": "sum by (path) (rate(ls_response_duration_seconds_sum{namespace=\"$namespace\"}[10m])) /\nsum by (path) (rate(ls_response_duration_seconds_count{namespace=\"$namespace\"}[10m]))",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -323,7 +323,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum(rate(ls_response_duration_seconds_bucket{namespace=\"$namespace\",path=\"/\"}[10m])) by (le, service))",
+              "expr": "histogram_quantile(0.95, sum(rate(ls_response_duration_seconds_bucket{namespace=\"$namespace\"}[10m])) by (le, path))",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"


### PR DESCRIPTION
Currently the overview dashboard for the assisted chat include a label constraint like `path="/"` in the Prometheus queries that it uses. But those metrics aren't cumulative, they are path specific, and they will always be zero for the root path. As a result the dashboard is always empty. This patch changes the dashboard so that it will show the paths aggregated by default, but also give the user the possibility to click in a specific path, in particular in the `/v1/query` and `/v1/streaming_query` paths, which are the ones releveant for the user.